### PR TITLE
Trying out fill / zfill commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -18,6 +18,11 @@ Include raw cyclic tag `{0, 1, ;}` in the compiled output.
 ### CLEAR _n_
 Deletes _n_ bits from datastring DATA. (Borrowed from ZX Spectrum BASIC).
 
+### FILL _n_
+Appends _n_ set bits (`1`) to datastring DATA, if leftmost databit is set.
+
+### ZFILL _n_
+Appends _n_ unset bits (`0`) to datastring DATA, if leftmost databit is set.
 
 ### INPUT _v_
 Assign the next bit of input data to variable _v_. Can only be used one at the beginning of the program. Special variable `_` can be used to consume the first input bit which always has to be one to allow a CT program to get started. (Borrowed from the Python convention).

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,7 +4,10 @@
 Comments. Ignored by the compiler.
 
 ### PRINT "_s_"
-Write (and then remove) STX / ETX bounded string, with start=1 and end=0 bits (10 bits per frame) to DATA (output data convention).
+Write STX / ETX bounded string, with start=1 and end=0 bits (10 bits per frame) to DATA (output data convention).
+
+### CHR$(_n_)
+Convert number _n_ into its ASCII character (8bit). Useful for sending ASCII control characters using `PRINT`.
 
 ### DATA
 Write binary / boolean / integer / string to DATA.

--- a/CTBASIC.py
+++ b/CTBASIC.py
@@ -18,6 +18,8 @@ ETX = '\x03'
 ASM_CT = re.compile(r'^[01;]*$')
 BIN = re.compile(r'^[01]*$')
 
+PRINTLINE = re.compile(r'("[^"]*"|CHR\$\(\d+\))')
+
 
 def parse_clear(line):
     n = int(line[6:])
@@ -46,10 +48,20 @@ def data(lst):
 
 def parse_print(line):
     r = []
-    s = STX + line[6:].strip('"') + ETX
+    line = PRINTLINE.split(line[6:])
+    s = ''
+    for v in line:
+        v = v.strip()
+        if not v:
+            continue
+        if v.startswith('CHR$'):
+            s += chr(int(re.search(r'\d+', v)[0]))
+        else:
+            s += v.strip('"')
+    s = STX + s + ETX
     for c in s:
         r += [1, c, 0]
-    return data(r) # + clear(len(s) * 10)
+    return data(r)
 
 
 def parse_asm(line):

--- a/CTBASIC.py
+++ b/CTBASIC.py
@@ -59,7 +59,7 @@ def parse_asm(line):
 
 
 def parse_bin(line):
-    b = line[4:]
+    b = line[4:].replace(' ', '')
     assert BIN.match(b)
     return b
 

--- a/CTBASIC.py
+++ b/CTBASIC.py
@@ -64,6 +64,12 @@ def parse_bin(line):
     return b
 
 
+# FILL / ZFILL parser
+def parse_fill(line, fill):
+    n = int(line[5:].strip())
+    return str(fill) * n
+
+
 def compile_(source):
     output = ''
     for line in source:
@@ -83,6 +89,10 @@ def compile_(source):
             append = parse_print(line)
         elif line.startswith('ASM'):
             append = parse_asm(line)
+        elif line.startswith('FILL'):
+            append = parse_fill(line, 1)
+        elif line.startswith('ZFILL'):
+            append = parse_fill(line, 0)
         elif line.startswith('ENDIF'):
             pass 
         elif line.startswith('END'):

--- a/examples/LOOP10.BAS
+++ b/examples/LOOP10.BAS
@@ -1,0 +1,21 @@
+REM Loop 10 times, printing an asterisk followed by a space each time.
+REM Currently does not terminate cleanly.
+
+
+REM INIT:
+  BIN  110
+  BIN 0010 0010 0010 0010 0010 0010 0010 0010 
+  BIN 0011
+  CLEAR 1
+
+REM START string output:
+  BIN 1 00000010 0
+  CLEAR 1
+
+REM MAIN BLOCK, output:
+  DATA 1, "*", 0, 1, " ", 0
+  CLEAR 1
+
+REM END string output:
+  BIN 1 00000011 0
+  CLEAR 1


### PR DESCRIPTION
Adds `FILL`, `ZFILL` and `CHR$()`

Not sure about the `FILL` naming, but the commands are useful. Will keep them for now and keep experimenting.

`CHR$()` uses C664 BASIC parenthesis, not the ZX Spectrum version without. All commands will probably need a full review and consistency checking once the basic spec has setlled.
