### PR TITLE
add Rule 110 compile target using M.Cook 2009 alg.

### DIFF
--- a/CTBASIC.py
+++ b/CTBASIC.py
@@ -149,8 +149,8 @@ Cook, Matthew (2009). "A Concrete View of Rule 110 Computation". In Neary, T.; W
 Electronic Proceedings in Theoretical Computer Science. Vol. 1. pp. 31–55.
 doi: 10.4204/EPTCS.1.4 (https://doi.org/10.4204/EPTCS.1.4)
     """
-    appendants = ct.split(';')
-    count = len(appendants) - 1
+    appendants = ct.split(';')[:-1]
+    count = len(appendants)
     if (count % 6) != 0:
         return rule110(expandsix(ct), data)
 
@@ -163,7 +163,7 @@ doi: 10.4204/EPTCS.1.4 (https://doi.org/10.4204/EPTCS.1.4)
             empty += 1
             right += 'L'
             continue
-        d = a.replace('0', 'II').replace('1', 'IJ')
+        d = a.replace('0', 'IJ').replace('1', 'II')
         d = 'KH' + d[1:]
         right += d
     right = right[1:] + right[0]

--- a/CTBASIC.py
+++ b/CTBASIC.py
@@ -13,6 +13,8 @@ import json
 import re
 import sys
 
+from CTBASIC.rule110 import rule110
+
 STX = '\x02'
 ETX = '\x03'
 ASM_CT = re.compile(r'^[01;]*$')
@@ -124,55 +126,6 @@ def bct(ct):
 def abct(ct):
     b = bct(ct)
     return bin_to_bb2(b)
-
-
-def expandsix(ct):
-    """
-    Expand CT appendants / productions to be a multiple of 6.
-    Using technique described in Cook 2009, 1.0.
-    """
-    # TODO: short cut -- if the CT is simple and isn't meant to loop (ends with an END of many CLEARs)
-    # pad the many ';' to a multiple of 6.
-    exp = ''
-    for c in ct:
-        if c == ';':
-            exp += ';' * 6
-        elif c in '01':
-            exp += c + '0' * 5
-    return exp
-
-
-def rule110(ct, data='1'):
-    """
-    Compile to Rule 110 'blocks' following the algorithm in 1.4 of:
-Cook, Matthew (2009). "A Concrete View of Rule 110 Computation". In Neary, T.; Woods, D.; Seda, A. K.; Murphy, N. (eds.).
-Electronic Proceedings in Theoretical Computer Science. Vol. 1. pp. 31–55.
-doi: 10.4204/EPTCS.1.4 (https://doi.org/10.4204/EPTCS.1.4)
-    """
-    appendants = ct.split(';')[:-1]
-    count = len(appendants)
-    if (count % 6) != 0:
-        return rule110(expandsix(ct), data)
-
-    central = 'C' + data.replace('0', 'ED').replace('1', 'FD')
-    central = central[:-1] + 'G'
-    right = ''
-    empty = 0
-    for a in appendants:
-        if not a:
-            empty += 1
-            right += 'L'
-            continue
-        d = a.replace('0', 'IJ').replace('1', 'II')
-        d = 'KH' + d[1:]
-        right += d
-    right = right[1:] + right[0]
-    v = (76 * ct.count('1') +
-         + 80 * ct.count('1')
-         + 60 * (count - empty)
-         + 43 * empty)
-    left = 'A' * v + 'B' + 'A' * 13 + 'B' + 'A' * 11 + 'B' + 'A' * 12 + 'B'
-    return left, central, right
 
 
 if __name__ == '__main__':

--- a/CTBASIC.py
+++ b/CTBASIC.py
@@ -126,6 +126,55 @@ def abct(ct):
     return bin_to_bb2(b)
 
 
+def expandsix(ct):
+    """
+    Expand CT appendants / productions to be a multiple of 6.
+    Using technique described in Cook 2009, 1.0.
+    """
+    # TODO: short cut -- if the CT is simple and isn't meant to loop (ends with an END of many CLEARs)
+    # pad the many ';' to a multiple of 6.
+    exp = ''
+    for c in ct:
+        if c == ';':
+            exp += ';' * 6
+        elif c in '01':
+            exp += c + '0' * 5
+    return exp
+
+
+def rule110(ct, data='1'):
+    """
+    Compile to Rule 110 'blocks' following the algorithm in 1.4 of:
+Cook, Matthew (2009). "A Concrete View of Rule 110 Computation". In Neary, T.; Woods, D.; Seda, A. K.; Murphy, N. (eds.).
+Electronic Proceedings in Theoretical Computer Science. Vol. 1. pp. 31–55.
+doi: 10.4204/EPTCS.1.4 (https://doi.org/10.4204/EPTCS.1.4)
+    """
+    appendants = ct.split(';')
+    count = len(appendants) - 1
+    if (count % 6) != 0:
+        return rule110(expandsix(ct), data)
+
+    central = 'C' + data.replace('0', 'ED').replace('1', 'FD')
+    central = central[:-1] + 'G'
+    right = ''
+    empty = 0
+    for a in appendants:
+        if not a:
+            empty += 1
+            right += 'L'
+            continue
+        d = a.replace('0', 'II').replace('1', 'IJ')
+        d = 'KH' + d[1:]
+        right += d
+    right = right[1:] + right[0]
+    v = (76 * ct.count('1') +
+         + 80 * ct.count('1')
+         + 60 * (count - empty)
+         + 43 * empty)
+    left = 'A' * v + 'B' + 'A' * 13 + 'B' + 'A' * 11 + 'B' + 'A' * 12 + 'B'
+    return left, central, right
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=ABOUT, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('source', help='CTBASIC source file to process', type=argparse.FileType('r'))
@@ -141,3 +190,5 @@ if __name__ == '__main__':
         print(bct(output))
     elif target == 'ABCT':
         print(abct(output))
+    elif target == '110':
+        print(rule110(output, data='1'))

--- a/CTBASIC/rule110.py
+++ b/CTBASIC/rule110.py
@@ -1,0 +1,47 @@
+def expandsix(ct):
+    """
+    Expand CT appendants / productions to be a multiple of 6.
+    Using technique described in Cook 2009, 1.0.
+    """
+    # TODO: short cut -- if the CT is simple and isn't meant to loop (ends with an END of many CLEARs)
+    # pad the many ';' to a multiple of 6.
+    exp = ''
+    for c in ct:
+        if c == ';':
+            exp += ';' * 6
+        elif c in '01':
+            exp += c + '0' * 5
+    return exp
+
+
+def rule110(ct, data='1'):
+    """
+    Compile to Rule 110 'blocks' following the algorithm in 1.4 of:
+      Cook, Matthew (2009). "A Concrete View of Rule 110 Computation". In Neary, T.; Woods, D.; Seda, A. K.; Murphy, N. (eds.).
+      Electronic Proceedings in Theoretical Computer Science. Vol. 1. pp. 31–55.
+      doi: 10.4204/EPTCS.1.4 (https://doi.org/10.4204/EPTCS.1.4)
+    """
+    appendants = ct.split(';')[:-1]
+    count = len(appendants)
+    if (count % 6) != 0:
+        return rule110(expandsix(ct), data)
+
+    central = 'C' + data.replace('0', 'ED').replace('1', 'FD')
+    central = central[:-1] + 'G'
+    right = ''
+    empty = 0
+    for a in appendants:
+        if not a:
+            empty += 1
+            right += 'L'
+            continue
+        d = a.replace('0', 'IJ').replace('1', 'II')
+        d = 'KH' + d[1:]
+        right += d
+    right = right[1:] + right[0]
+    v = (76 * ct.count('1') +
+         + 80 * ct.count('1')
+         + 60 * (count - empty)
+         + 43 * empty)
+    left = 'A' * v + 'B' + 'A' * 13 + 'B' + 'A' * 11 + 'B' + 'A' * 12 + 'B'
+    return left, central, right

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 A [Cyclic Tag](https://esolangs.org/wiki/Cyclic_tag_system) BASIC compiler.
 
-Compiles a reduced dialect of BASIC into [CT](https://esolangs.org/wiki/Bitwise_Cyclic_Tag#The_language_CT), [BCT](https://esolangs.org/wiki/Bitwise_Cyclic_Tag), or [ABCT](https://github.com/hornc/abctag).
+Compiles a reduced dialect of BASIC into one of the following compilation targets:
+
+* [CT](https://esolangs.org/wiki/Bitwise_Cyclic_Tag#The_language_CT) (Cyclic Tag)
+* [BCT](https://esolangs.org/wiki/Bitwise_Cyclic_Tag) (Bitwise Cyclic Tag)
+* [ABCT](https://github.com/hornc/abctag) (Arithmetic Bitwise Cyclic Tag)
+* [Rule 110](https://en.wikipedia.org/wiki/Rule_110), using the ["blocks of bits" construction developed and described by Matthew Cook](https://doi.org/10.4204/eptcs.1.4)
 
 Experimental / work in progress. Details and usabilty are still being worked out.
 

--- a/examples/Cook_1_4_example.bas
+++ b/examples/Cook_1_4_example.bas
@@ -1,0 +1,14 @@
+REM Appendant example given in section 1.4 of
+REM M. Cook (2009) "A Concrete View of Rule 110 Computation"
+REM doi: 10.4204/EPTCS.1.4
+
+ASM 10;
+ASM 0110;
+ASM ;
+ASM ;
+
+REM Modified slightly to give the required multiple of 6 appendants:
+ASM ;
+ASM ;
+
+REM Expected RHS: HIIJKHJIIIIIJLLLLK


### PR DESCRIPTION
ref: https://doi.org/10.4204/eptcs.1.4

This is possibly / likely buggy.

Not quite sure how to test this. It raises some issues about the format of some of my test programs which aren't designed to cycle, and how the output convention of byte encoding into 10 bit frames will survive the multiple-of-six appendant padding from the paper.

Leaving the PR here as a starting point for further investigation.

Section 1.4 of Cook 2009 shows the letter designated rule 110 blocks that the output compiles to. Compiled output is in terms of these block codes -- assembling them into infinitely tiled Rule 110 cells is another task.

Output is in terms of three sections:  Left, Center, Right.

The Left and Right sections are to be infinitely repeated in the rule 110 setup, Center is the initial data tape and is currently hard coded to a single `1` bit by default. The code can encode other data strings, but currently the compiler does not accept a different starting input data string. Center is not tiled in the rule 110 encoding, it is used once as is.

Testing the example from the paper:

    ./CTBASIC.py examples/Cook_1_4_example.bas -t110

```
('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAABAAAAAAAAAAABAAAAAAAAAAAAB', 
'CFG',
'HIIJKHJIIIIIJLLLLK')
```

Which gives the expected `HIIJKHJIIIIIJLLLLK` ; this is padded by 2 extra `L` at the end to satisfy the multiple of 6 requirement from section 1 compared to the exact example in the paper.:

> "{YN, NYYN, 0, 0} would become HIIJKHJIIIIIJLLK"

